### PR TITLE
fix(shared-global): preserve other env backend pools during single-env applies

### DIFF
--- a/.github/workflows/terraform-shared-global.yml
+++ b/.github/workflows/terraform-shared-global.yml
@@ -163,6 +163,22 @@ jobs:
           echo "FE_FQDN_PROD=$FE_FQDN_PROD" >> $GITHUB_ENV
           echo "BE_FQDN_PROD=$BE_FQDN_PROD" >> $GITHUB_ENV
 
+      - name: Resolve existing Container App FQDNs (all envs)
+        run: |
+          for ENV in dev test prod; do
+            RG="ismd-validator-$ENV"
+            FE="ismd-validator-frontend-$ENV"
+            BE="ismd-validator-backend-$ENV"
+            FE_FQDN=$(az containerapp show -g "$RG" -n "$FE" --query properties.latestRevisionFqdn -o tsv 2>/dev/null || true)
+            BE_FQDN=$(az containerapp show -g "$RG" -n "$BE" --query properties.latestRevisionFqdn -o tsv 2>/dev/null || true)
+            if [ -n "$FE_FQDN" ]; then
+              echo "FE_FQDN_${ENV^^}=$FE_FQDN" >> $GITHUB_ENV
+            fi
+            if [ -n "$BE_FQDN" ]; then
+              echo "BE_FQDN_${ENV^^}=$BE_FQDN" >> $GITHUB_ENV
+            fi
+          done
+
       - name: Terraform Init
         run: terraform init
 
@@ -181,6 +197,13 @@ jobs:
           frontend_app_name = "${FE_APP}"
           backend_app_name  = "${BE_APP}"
           EOF
+          # Preserve existing DEV FQDNs when available (prevents clearing DEV pools)
+          if [ -n "${FE_FQDN_DEV:-}" ]; then
+            echo "frontend_fqdn = \"${FE_FQDN_DEV}\"" >> .tfvars/terraform.tfvars
+          fi
+          if [ -n "${BE_FQDN_DEV:-}" ]; then
+            echo "backend_fqdn  = \"${BE_FQDN_DEV}\"" >> .tfvars/terraform.tfvars
+          fi
           if [ -n "${DOMAIN_INPUT}" ]; then
             echo "container_app_environment_domain = \"${DOMAIN_INPUT}\"" >> .tfvars/terraform.tfvars
           fi

--- a/shared-global/main.tf
+++ b/shared-global/main.tf
@@ -19,8 +19,8 @@ module "shared_global" {
 
   # Construct FQDNs from provided domain to avoid circular dep
   # Treat these as DEV defaults when environment == dev
-  frontend_fqdn = var.environment == "dev" && var.container_app_environment_domain != "" ? "${var.frontend_app_name}-dev.${var.container_app_environment_domain}" : ""
-  backend_fqdn  = var.environment == "dev" && var.container_app_environment_domain != "" ? "${var.backend_app_name}-dev.${var.container_app_environment_domain}" : ""
+  frontend_fqdn = var.frontend_fqdn != "" ? var.frontend_fqdn : (var.environment == "dev" && var.container_app_environment_domain != "" ? "${var.frontend_app_name}-dev.${var.container_app_environment_domain}" : "")
+  backend_fqdn  = var.backend_fqdn  != "" ? var.backend_fqdn  : (var.environment == "dev" && var.container_app_environment_domain != "" ? "${var.backend_app_name}-dev.${var.container_app_environment_domain}"  : "")
 
   # For TEST/PROD, prefer explicit overrides; else construct when this workflow is called with that environment and domain is provided
   frontend_fqdn_test = var.frontend_fqdn_test != "" ? var.frontend_fqdn_test : (var.environment == "test" && var.container_app_environment_domain != "" ? "${var.frontend_app_name}-test.${var.container_app_environment_domain}" : "")

--- a/shared-global/variables.tf
+++ b/shared-global/variables.tf
@@ -26,6 +26,19 @@ variable "container_app_environment_domain" {
   type        = string
 }
 
+# Optional explicit DEV FQDNs (used to preserve DEV pools when applying other environments)
+variable "frontend_fqdn" {
+  description = "Frontend FQDN for DEV"
+  type        = string
+  default     = ""
+}
+
+variable "backend_fqdn" {
+  description = "Backend FQDN for DEV"
+  type        = string
+  default     = ""
+}
+
 variable "dev_hostname" {
   description = "Hostname for DEV (ASCII/punycode)"
   type        = string


### PR DESCRIPTION
fix(shared-global): preserve other env backend pools during single-env applies
- Add optional DEV FQDN vars (frontend_fqdn, backend_fqdn) in infrastructure/shared-global/variables.tf
- Prefer explicit DEV FQDNs in infrastructure/shared-global/main.tf to avoid clearing DEV when applying TEST/PROD
- Re-add FQDN discovery in infrastructure/.github/workflows/terraform-shared-global.yml and inject existing DEV FQDNs into tfvars
- Also continues to pass TEST/PROD FQDNs when available, so PROD runs won’t clear DEV/TEST