### PR TITLE
Refactor, split infra deployment and image updates responsibility

### DIFF
--- a/.github/workflows/terraform-shared-global.yml
+++ b/.github/workflows/terraform-shared-global.yml
@@ -80,17 +80,14 @@ on:
         description: "Optional explicit PROD backend FQDN (container app)."
         required: false
         type: string
-  repository_dispatch:
-    types:
-      - update-shared-global
 
 jobs:
   terraform:
     name: 'Terraform (Shared Global)'
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'prod' && 'PROD' || github.event.inputs.environment == 'test' && 'TEST' || 'DEV') || (github.event_name == 'repository_dispatch' && (github.event.client_payload.environment == 'prod' && 'PROD' || github.event.client_payload.environment == 'test' && 'TEST' || 'DEV')) }}
+    environment: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'prod' && 'PROD' || github.event.inputs.environment == 'test' && 'TEST' || 'DEV')) || (inputs.environment == 'prod' && 'PROD' || inputs.environment == 'test' && 'TEST' || 'DEV') }}
     concurrency:
-      group: shared-global-${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment) || (github.event_name == 'repository_dispatch' && github.event.client_payload.environment) || inputs.environment || 'dev' }}
+      group: shared-global-${{ github.event.inputs.environment || inputs.environment || 'dev' }}
       cancel-in-progress: false
     defaults:
       run:
@@ -138,29 +135,16 @@ jobs:
             FE_FQDN_PROD='${{ inputs.frontend_fqdn_prod }}'
             BE_FQDN_PROD='${{ inputs.backend_fqdn_prod }}'
           else
-            # Fall back to direct event inputs
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              ENV="${{ github.event.inputs.environment }}"
-              DOMAIN_INPUT="${{ github.event.inputs.container_app_environment_domain }}"
-              DEV_HOST="${{ github.event.inputs.dev_hostname }}"
-              TEST_HOST="${{ github.event.inputs.test_hostname }}"
-              PROD_HOST="${{ github.event.inputs.prod_hostname }}"
-              FE_FQDN_TEST="${{ github.event.inputs.frontend_fqdn_test }}"
-              BE_FQDN_TEST="${{ github.event.inputs.backend_fqdn_test }}"
-              FE_FQDN_PROD="${{ github.event.inputs.frontend_fqdn_prod }}"
-              BE_FQDN_PROD="${{ github.event.inputs.backend_fqdn_prod }}"
-            else
-              # repository_dispatch
-              ENV="${{ github.event.client_payload.environment }}"
-              DOMAIN_INPUT="${{ github.event.client_payload.container_app_environment_domain }}"
-              DEV_HOST="${{ github.event.client_payload.dev_hostname }}"
-              TEST_HOST="${{ github.event.client_payload.test_hostname }}"
-              PROD_HOST="${{ github.event.client_payload.prod_hostname }}"
-              FE_FQDN_TEST="${{ github.event.client_payload.frontend_fqdn_test }}"
-              BE_FQDN_TEST="${{ github.event.client_payload.backend_fqdn_test }}"
-              FE_FQDN_PROD="${{ github.event.client_payload.frontend_fqdn_prod }}"
-              BE_FQDN_PROD="${{ github.event.client_payload.backend_fqdn_prod }}"
-            fi
+            # Fall back to workflow_dispatch inputs
+            ENV="${{ github.event.inputs.environment }}"
+            DOMAIN_INPUT="${{ github.event.inputs.container_app_environment_domain }}"
+            DEV_HOST="${{ github.event.inputs.dev_hostname }}"
+            TEST_HOST="${{ github.event.inputs.test_hostname }}"
+            PROD_HOST="${{ github.event.inputs.prod_hostname }}"
+            FE_FQDN_TEST="${{ github.event.inputs.frontend_fqdn_test }}"
+            BE_FQDN_TEST="${{ github.event.inputs.backend_fqdn_test }}"
+            FE_FQDN_PROD="${{ github.event.inputs.frontend_fqdn_prod }}"
+            BE_FQDN_PROD="${{ github.event.inputs.backend_fqdn_prod }}"
           fi
 
           # Ensure we always have an environment (default to dev)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,13 +1,7 @@
 name: 'Terraform Deployment'
 
 on:
-  # Triggered from other repositories
-  repository_dispatch:
-    types:
-      - new-image-dev
-      - new-image-test
-      - new-image-prod
-  # Manual trigger for testing without PRs
+  # Manual trigger for infrastructure updates
   workflow_dispatch:
     inputs:
       environment:
@@ -19,17 +13,6 @@ on:
           - test
           - prod
         default: dev
-      component:
-        description: "Component to deploy"
-        required: true
-        type: choice
-        options:
-          - frontend
-          - backend
-      image_tag:
-        description: "Image version tag in the format MAJOR.MINOR.PATCH with optional suffix. Examples: 0.1.0-c255c74, 0.0.1-snapshot-deff379 (prefix 'v' also allowed)."
-        required: true
-        type: string
 
 jobs:
   shared_global_pre:
@@ -37,7 +20,7 @@ jobs:
     uses: datagov-cz/ismd-infrastructure/.github/workflows/terraform-shared-global.yml@dev
     secrets: inherit
     with:
-      environment: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'prod' && 'prod' || github.event.inputs.environment == 'test' && 'test' || 'dev') || (github.event.action == 'new-image-prod' && 'prod' || github.event.action == 'new-image-test' && 'test' || 'dev') }}
+      environment: ${{ github.event.inputs.environment }}
       dev_hostname: ${{ vars.DEV_HOSTNAME }}
       test_hostname: ${{ vars.TEST_HOSTNAME }}
       prod_hostname: ${{ vars.PROD_HOSTNAME }}
@@ -48,7 +31,7 @@ jobs:
     name: 'Terraform'
     runs-on: ubuntu-latest
     needs: [shared_global_pre]
-    environment: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'prod' && 'PROD' || github.event.inputs.environment == 'test' && 'TEST' || 'DEV') || (github.event.action == 'new-image-prod' && 'PROD' || github.event.action == 'new-image-test' && 'TEST' || 'DEV') }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'PROD' || github.event.inputs.environment == 'test' && 'TEST' || 'DEV' }}
     outputs:
       job_status: ${{ job.status }}
     
@@ -85,14 +68,7 @@ jobs:
     - name: Select Environment
       id: select-env
       run: |
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          # Manual dispatch path
-          ENV="${{ github.event.inputs.environment }}"
-        else
-          # repository_dispatch: extract env from action (new-image-<env>)
-          EVENT_TYPE="${{ github.event.action }}"
-          ENV="${EVENT_TYPE#new-image-}"
-        fi
+        ENV="${{ github.event.inputs.environment }}"
         echo "ENVIRONMENT=$ENV" >> $GITHUB_ENV
         echo "STATE_KEY=$ENV/terraform.tfstate" >> $GITHUB_ENV
     
@@ -137,116 +113,12 @@ jobs:
     - name: Terraform Workspace
       run: terraform workspace select ${{ env.ENVIRONMENT }} || terraform workspace new ${{ env.ENVIRONMENT }}
     
-    - name: Resolve Container Apps Environment Domain
-      run: |
-        ENV="${{ env.ENVIRONMENT }}"
-        CAE_NAME="ismd-validator-environment-$ENV"
-        CAE_RG="ismd-validator-$ENV"
-        DOMAIN=$(az containerapp env show -g "$CAE_RG" -n "$CAE_NAME" --query properties.defaultDomain -o tsv 2>/dev/null || true)
-        if [ -n "$DOMAIN" ]; then
-          echo "CONTAINER_ENV_DOMAIN=$DOMAIN" >> $GITHUB_ENV
-        fi
-    
-    - name: Create Variable File
-      run: |
-        # Create directory if it doesn't exist
-        mkdir -p environments/${{ env.ENVIRONMENT }}
-        
-        # Set default location
-        LOCATION="germanywestcentral"
-        
-        # Set resource group names based on environment
-        SHARED_RG="ismd-shared-${{ env.ENVIRONMENT }}"
-        VALIDATOR_RG="ismd-validator-${{ env.ENVIRONMENT }}"
-        
-        # Set image repositories based on environment
-        # Only dev images have environment suffix, test/prod use base image name
-        if [ "${{ env.ENVIRONMENT }}" = "dev" ]; then
-          FE_REPO="ghcr.io/datagov-cz/ismd-validator-frontend-dev"
-          BE_REPO="ghcr.io/datagov-cz/ismd-validator-backend-dev"
-        else
-          FE_REPO="ghcr.io/datagov-cz/ismd-validator-frontend"
-          BE_REPO="ghcr.io/datagov-cz/ismd-validator-backend"
-        fi
-        
-        # Determine which component changed and enforce required version format for it.
-        COMPONENT="${{ github.event.client_payload.component }}"
-        if [ -z "$COMPONENT" ]; then COMPONENT="${{ github.event.inputs.component }}"; fi
-        NEW_TAG="${{ github.event.client_payload.image_tag }}"
-        if [ -z "$NEW_TAG" ]; then NEW_TAG="${{ github.event.inputs.image_tag }}"; fi
-        ENVIRONMENT="${{ env.ENVIRONMENT }}"
-        VALIDATOR_RG="ismd-validator-${{ env.ENVIRONMENT }}"
-        
-        SEMVER_RE='^v?[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?$'
-        
-        if [ -z "$COMPONENT" ] || [ -z "$NEW_TAG" ]; then
-          echo "Error: repository_dispatch must include component and image_tag." >&2
-          exit 1
-        fi
-        if ! echo "$NEW_TAG" | grep -Eq "$SEMVER_RE"; then
-          echo "Error: image_tag '$NEW_TAG' doesn't match MAJOR.MINOR.PATCH with optional suffix (e.g., 0.1.0-c255c74 or 0.0.1-snapshot-deff379)." >&2
-          exit 1
-        fi
-        
-        # Fetch current tags from Azure for the component that did NOT change to preserve it
-        if [ "$COMPONENT" = "frontend" ]; then
-          FE_TAG="$NEW_TAG"
-          BE_IMAGE=$(az containerapp show -g "$VALIDATOR_RG" -n "ismd-validator-backend-$ENVIRONMENT" --query "properties.template.containers[0].image" -o tsv 2>/dev/null || true)
-          BE_TAG=$(echo "$BE_IMAGE" | awk -F: '{print $2}')
-          if [ -z "$BE_TAG" ]; then
-            echo "Error: Could not determine existing backend image tag. Ensure backend app exists or provide a backend tag in a separate event first." >&2
-            exit 1
-          fi
-        elif [ "$COMPONENT" = "backend" ]; then
-          BE_TAG="$NEW_TAG"
-          FE_IMAGE=$(az containerapp show -g "$VALIDATOR_RG" -n "ismd-validator-frontend-$ENVIRONMENT" --query "properties.template.containers[0].image" -o tsv 2>/dev/null || true)
-          FE_TAG=$(echo "$FE_IMAGE" | awk -F: '{print $2}')
-          if [ -z "$FE_TAG" ]; then
-            echo "Error: Could not determine existing frontend image tag. Ensure frontend app exists or provide a frontend tag in a separate event first." >&2
-            exit 1
-          fi
-        else
-          echo "Error: Unsupported component '$COMPONENT' (expected 'frontend' or 'backend')." >&2
-          exit 1
-        fi
-        
-        # Final validation of both tags
-        if ! echo "$FE_TAG" | grep -Eq "$SEMVER_RE"; then
-          echo "Error: resolved frontend tag '$FE_TAG' doesn't match MAJOR.MINOR.PATCH with optional suffix (e.g., 0.1.0-c255c74)." >&2
-          exit 1
-        fi
-        if ! echo "$BE_TAG" | grep -Eq "$SEMVER_RE"; then
-          echo "Error: resolved backend tag '$BE_TAG' doesn't match MAJOR.MINOR.PATCH with optional suffix (e.g., 0.0.1-snapshot-deff379)." >&2
-          exit 1
-        fi
-        
-        # Create dynamic tfvars file
-        cat > environments/${{ env.ENVIRONMENT }}/terraform.tfvars << EOF
-        environment = "${{ env.ENVIRONMENT }}"
-        location = "$LOCATION"
-        shared_resource_group_name = "$SHARED_RG"
-        validator_resource_group_name = "$VALIDATOR_RG"
-        
-        # Container images
-        frontend_image = "$FE_REPO"
-        frontend_image_tag = "$FE_TAG"
-        backend_image = "$BE_REPO"
-        backend_image_tag = "$BE_TAG"
-        EOF
-        
-        # Append container app environment domain if we resolved it
-        if [ -n "${CONTAINER_ENV_DOMAIN:-}" ]; then
-          echo "container_app_environment_domain = \"${CONTAINER_ENV_DOMAIN}\"" >> environments/${{ env.ENVIRONMENT }}/terraform.tfvars
-        fi
-        
-        # Show created file for debugging
-        echo "Created variable file:"
-        cat environments/${{ env.ENVIRONMENT }}/terraform.tfvars
+    # Note: Using committed terraform.tfvars files from each environment directory.
+    # Image tags are managed via lifecycle ignore_changes in Terraform.
     
     - name: Terraform Plan
       run: |
-        # Run plan with the dynamically created variable file
-        terraform plan -var-file="environments/${{ env.ENVIRONMENT }}/terraform.tfvars" -out=tfplan
+        terraform plan -out=tfplan
         
         # Display the plan for review
         echo "\n\nTerraform Plan Output:\n"
@@ -256,95 +128,14 @@ jobs:
       run: |
         terraform apply -auto-approve tfplan
 
-  get_domain:
-    name: 'Resolve Container App Environment Domain'
-    runs-on: ubuntu-latest
-    needs: [terraform]
-    outputs:
-      domain: ${{ steps.out.outputs.domain }}
-      env_lower: ${{ steps.out.outputs.env_lower }}
-    steps:
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: Resolve domain
-        id: out
-        run: |
-          # Determine environment (lowercase) from event
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ENV_LOWER="${{ github.event.inputs.environment }}"
-          else
-            case "${{ github.event.action }}" in
-              new-image-prod) ENV_LOWER="prod" ;;
-              new-image-test) ENV_LOWER="test" ;;
-              *) ENV_LOWER="dev" ;;
-            esac
-          fi
-          CAE_NAME="ismd-validator-environment-$ENV_LOWER"
-          CAE_RG="ismd-validator-$ENV_LOWER"
-          DOMAIN=$(az containerapp env show -g "$CAE_RG" -n "$CAE_NAME" --query properties.defaultDomain -o tsv 2>/dev/null || true)
-          echo "env_lower=$ENV_LOWER" >> $GITHUB_OUTPUT
-          echo "domain=$DOMAIN" >> $GITHUB_OUTPUT
-
   shared_global_post:
     name: 'Shared-Global Post'
-    if: needs.get_domain.outputs.domain != ''
     uses: datagov-cz/ismd-infrastructure/.github/workflows/terraform-shared-global.yml@dev
     secrets: inherit
-    needs: [get_domain]
+    needs: [terraform]
     with:
-      environment: ${{ needs.get_domain.outputs.env_lower }}
+      environment: ${{ github.event.inputs.environment }}
       dev_hostname: ${{ vars.DEV_HOSTNAME }}
       test_hostname: ${{ vars.TEST_HOSTNAME }}
       prod_hostname: ${{ vars.PROD_HOSTNAME }}
-      container_app_environment_domain: ${{ needs.get_domain.outputs.domain }}
       apply: true
-
-  report-status:
-    name: Report Deployment Status
-    runs-on: ubuntu-latest
-    needs: [shared_global_pre, terraform, get_domain, shared_global_post]
-    if: always()
-    steps:
-      - name: Set deployment state (success)
-        if: ${{ needs.terraform.outputs.job_status == 'success' }}
-        run: echo "STATE=success" >> $GITHUB_ENV
-
-      - name: Set deployment state (failure)
-        if: ${{ needs.terraform.outputs.job_status != 'success' }}
-        run: echo "STATE=failure" >> $GITHUB_ENV
-
-      - name: Compose status and context
-        id: ctx
-        run: |
-          echo "state=${STATE}" >> $GITHUB_OUTPUT
-          echo "run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
-          # Extract environment from event (repository_dispatch or workflow_dispatch)
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            EVENT_TYPE="${{ github.event.action }}" # e.g., new-image-dev
-            ENV="${EVENT_TYPE#new-image-}"
-          else
-            ENV="${{ github.event.inputs.environment }}"
-          fi
-          echo "environment=$ENV" >> $GITHUB_OUTPUT
-      
-      - name: Notify source repository
-        uses: peter-evans/repository-dispatch@v4
-        continue-on-error: true
-        with:
-          token: ${{ secrets.SOURCE_REPO_TOKEN }}
-          repository: ${{ github.event.client_payload.source_repo }}
-          event-type: infra-deploy-complete
-          client-payload: |
-            {
-              "deployment_id": "${{ github.event.client_payload.source_deployment_id }}",
-              "state": "${{ steps.ctx.outputs.state }}",
-              "environment": "${{ steps.ctx.outputs.environment }}",
-              "infra_run_url": "${{ steps.ctx.outputs.run_url }}",
-              "component": "${{ github.event.client_payload.component }}",
-              "image_tag": "${{ github.event.client_payload.image_tag }}",
-              "infra_repo": "${{ github.repository }}",
-              "source_run_url": "${{ github.event.client_payload.source_run_url }}",
-              "pr_url": "${{ github.event.client_payload.pr_url }}"
-            }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -1,18 +1,6 @@
 # Production Environment Configuration
 
 # Variables for the production environment
-variable "create_environment" {
-  description = "Whether to create the container app environment"
-  type        = bool
-  default     = true
-}
-
-variable "create_apps" {
-  description = "Whether to create the container apps"
-  type        = bool
-  default     = true
-}
-
 variable "environment" {
   description = "Environment name (dev, test, prod)"
   type        = string
@@ -44,12 +32,13 @@ variable "frontend_image" {
 }
 
 variable "frontend_image_tag" {
-  description = "Tag for the frontend container image (e.g., '1.0.0' or '1.0.0-abc1234' for development)"
+  description = "Tag for the frontend container image (e.g., 'latest', '1.0.0' or '1.0.0-abc1234')"
   type        = string
+  default     = "latest"
 
   validation {
-    condition     = can(regex("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9-]+)?$", var.frontend_image_tag))
-    error_message = "The frontend_image_tag must be a valid version number (e.g., '1.0.0' or '1.0.0-abc1234')."
+    condition     = var.frontend_image_tag == "latest" || can(regex("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9-]+)?$", var.frontend_image_tag))
+    error_message = "The frontend_image_tag must be 'latest' or a valid version number (e.g., '1.0.0' or '1.0.0-abc1234')."
   }
 }
 
@@ -60,12 +49,13 @@ variable "backend_image" {
 }
 
 variable "backend_image_tag" {
-  description = "Tag for the backend container image (e.g., '1.0.0' or '1.0.0-abc1234' for development)"
+  description = "Tag for the backend container image (e.g., 'latest', '1.0.0' or '1.0.0-abc1234')"
   type        = string
+  default     = "latest"
 
   validation {
-    condition     = can(regex("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9-]+)?$", var.backend_image_tag))
-    error_message = "The backend_image_tag must be a valid version number (e.g., '1.0.0' or '1.0.0-abc1234')."
+    condition     = var.backend_image_tag == "latest" || can(regex("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9-]+)?$", var.backend_image_tag))
+    error_message = "The backend_image_tag must be 'latest' or a valid version number (e.g., '1.0.0' or '1.0.0-abc1234')."
   }
 }
 
@@ -108,23 +98,20 @@ variable "backend_app_name" {
   default     = "ismd-validator-backend"
 }
 
-variable "container_app_environment_id" {
-  description = "ID of the container app environment"
-  type        = string
-  default     = ""
-}
+# Validator resource group
+resource "azurerm_resource_group" "validator" {
+  name     = var.validator_resource_group_name
+  location = var.location
 
-
-variable "container_app_environment_default_domain" {
-  description = "Default domain of the container app environment"
-  type        = string
-  default     = ""
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+    Application = "Validator"
+  }
 }
 
 # Shared resources (networking, resource groups, etc.)
 module "shared" {
-  # Remove count to ensure stable resource addressing
-  # count  = var.create_environment ? 1 : 0
   source = "../../modules/shared"
 
   environment                     = var.environment
@@ -133,24 +120,11 @@ module "shared" {
   vnet_address_space              = "10.3.0.0/16"        # PROD: 10.3.x.x
   vnet_address_space_ipv6         = "fd00:db8:decd::/48" # PROD: unique IPv6
   validator_subnet_address_prefix = "10.3.2.0/23"        # PROD: within 10.3.0.0/16
+  tool_subnet_address_prefix      = "10.3.4.0/23"        # PROD: within 10.3.0.0/16
 }
 
-# Create the container app environment if requested
-module "validator_environment" {
-  count  = var.create_environment ? 1 : 0
-  source = "../../modules/validator_environment"
-
-  environment         = var.environment
-  location            = var.location
-  resource_group_name = var.validator_resource_group_name
-  subnet_id           = var.create_environment ? module.shared.validator_subnet_id : ""
-
-  depends_on = [module.shared]
-}
-
-# Create the container apps if requested
+# Create validator apps using shared Container App Environment
 module "validator_apps" {
-  count  = var.create_apps ? 1 : 0
   source = "../../modules/validator_apps"
 
   environment         = var.environment
@@ -159,8 +133,8 @@ module "validator_apps" {
 
   # Required by the module
   shared_resource_group_name               = var.shared_resource_group_name
-  container_app_environment_id             = var.create_environment ? module.validator_environment[0].container_app_environment_id : var.container_app_environment_id
-  container_app_environment_default_domain = var.create_environment ? module.validator_environment[0].default_domain : var.container_app_environment_default_domain
+  container_app_environment_id             = module.shared.shared_container_app_environment_id
+  container_app_environment_default_domain = module.shared.shared_container_app_environment_default_domain
 
   # Container Images
   frontend_image     = var.frontend_image
@@ -176,11 +150,13 @@ module "validator_apps" {
   frontend_app_name = var.frontend_app_name
   backend_app_name  = var.backend_app_name
 
-  # Workload profile configuration - using Dedicated profile for VNet integration
+  # Workload profile configuration
   workload_profile_name = "default"
   workload_profile_type = "D4"
+  
   depends_on = [
-    module.validator_environment
+    module.shared,
+    azurerm_resource_group.validator
   ]
 }
 
@@ -190,7 +166,7 @@ output "shared_resource_group_name" {
 }
 
 output "validator_resource_group_name" {
-  value = length(module.validator_environment) > 0 ? module.validator_environment[0].resource_group_name : ""
+  value = azurerm_resource_group.validator.name
 }
 
 output "app_gateway_public_ip" {
@@ -198,19 +174,21 @@ output "app_gateway_public_ip" {
 }
 
 output "validator_frontend_fqdn" {
-  value = length(module.validator_apps) > 0 ? module.validator_apps[0].frontend_fqdn : ""
+  value = module.validator_apps.frontend_fqdn
 }
 
 output "validator_backend_fqdn" {
-  value = length(module.validator_apps) > 0 ? module.validator_apps[0].backend_fqdn : ""
+  value = module.validator_apps.backend_fqdn
 }
 
-output "container_app_environment_id" {
-  value = length(module.validator_environment) > 0 ? module.validator_environment[0].container_app_environment_id : ""
+output "shared_container_app_environment_id" {
+  description = "ID of the shared Container App Environment"
+  value       = module.shared.shared_container_app_environment_id
 }
 
-output "container_app_environment_name" {
-  value = length(module.validator_environment) > 0 ? module.validator_environment[0].container_app_environment_name : ""
+output "shared_container_app_environment_name" {
+  description = "Name of the shared Container App Environment"
+  value       = module.shared.shared_container_app_environment_name
 }
 
 # VNet Peering from this environment's VNet to the shared global VNet

--- a/environments/test/main.tf
+++ b/environments/test/main.tf
@@ -1,18 +1,6 @@
 # Test Environment Configuration
 
 # Variables for the test environment
-variable "create_environment" {
-  description = "Whether to create the container app environment"
-  type        = bool
-  default     = true
-}
-
-variable "create_apps" {
-  description = "Whether to create the container apps"
-  type        = bool
-  default     = true
-}
-
 variable "environment" {
   description = "Environment name (dev, test, prod)"
   type        = string
@@ -44,12 +32,13 @@ variable "frontend_image" {
 }
 
 variable "frontend_image_tag" {
-  description = "Tag for the frontend container image (e.g., '1.0.0' or '1.0.0-abc1234' for development)"
+  description = "Tag for the frontend container image (e.g., 'latest', '1.0.0' or '1.0.0-abc1234')"
   type        = string
+  default     = "latest"
 
   validation {
-    condition     = can(regex("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9-]+)?$", var.frontend_image_tag))
-    error_message = "The frontend_image_tag must be a valid version number (e.g., '1.0.0' or '1.0.0-abc1234')."
+    condition     = var.frontend_image_tag == "latest" || can(regex("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9-]+)?$", var.frontend_image_tag))
+    error_message = "The frontend_image_tag must be 'latest' or a valid version number (e.g., '1.0.0' or '1.0.0-abc1234')."
   }
 }
 
@@ -60,12 +49,13 @@ variable "backend_image" {
 }
 
 variable "backend_image_tag" {
-  description = "Tag for the backend container image (e.g., '1.0.0' or '1.0.0-abc1234' for development)"
+  description = "Tag for the backend container image (e.g., 'latest', '1.0.0' or '1.0.0-abc1234')"
   type        = string
+  default     = "latest"
 
   validation {
-    condition     = can(regex("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9-]+)?$", var.backend_image_tag))
-    error_message = "The backend_image_tag must be a valid version number (e.g., '1.0.0' or '1.0.0-abc1234')."
+    condition     = var.backend_image_tag == "latest" || can(regex("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9-]+)?$", var.backend_image_tag))
+    error_message = "The backend_image_tag must be 'latest' or a valid version number (e.g., '1.0.0' or '1.0.0-abc1234')."
   }
 }
 
@@ -108,23 +98,20 @@ variable "backend_app_name" {
   default     = "ismd-validator-backend"
 }
 
-variable "container_app_environment_id" {
-  description = "ID of the container app environment"
-  type        = string
-  default     = ""
-}
+# Validator resource group
+resource "azurerm_resource_group" "validator" {
+  name     = var.validator_resource_group_name
+  location = var.location
 
-
-variable "container_app_environment_default_domain" {
-  description = "Default domain of the container app environment"
-  type        = string
-  default     = ""
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+    Application = "Validator"
+  }
 }
 
 # Shared resources (networking, resource groups, etc.)
 module "shared" {
-  # Remove count to ensure stable resource addressing
-  # count  = var.create_environment ? 1 : 0
   source = "../../modules/shared"
 
   environment                     = var.environment
@@ -133,24 +120,11 @@ module "shared" {
   vnet_address_space              = "10.2.0.0/16"        # TEST: 10.2.x.x (avoids conflict with shared-global 10.1.x.x)
   vnet_address_space_ipv6         = "fd00:db8:decc::/48" # TEST: unique IPv6
   validator_subnet_address_prefix = "10.2.2.0/23"        # TEST: within 10.2.0.0/16
+  tool_subnet_address_prefix      = "10.2.4.0/23"        # TEST: within 10.2.0.0/16
 }
 
-# Create the container app environment if requested
-module "validator_environment" {
-  count  = var.create_environment ? 1 : 0
-  source = "../../modules/validator_environment"
-
-  environment         = var.environment
-  location            = var.location
-  resource_group_name = var.validator_resource_group_name
-  subnet_id           = var.create_environment ? module.shared.validator_subnet_id : ""
-
-  depends_on = [module.shared]
-}
-
-# Create the container apps if requested
+# Create validator apps using shared Container App Environment
 module "validator_apps" {
-  count  = var.create_apps ? 1 : 0
   source = "../../modules/validator_apps"
 
   environment         = var.environment
@@ -159,8 +133,8 @@ module "validator_apps" {
 
   # Required by the module
   shared_resource_group_name               = var.shared_resource_group_name
-  container_app_environment_id             = var.create_environment ? module.validator_environment[0].container_app_environment_id : var.container_app_environment_id
-  container_app_environment_default_domain = var.create_environment ? module.validator_environment[0].default_domain : var.container_app_environment_default_domain
+  container_app_environment_id             = module.shared.shared_container_app_environment_id
+  container_app_environment_default_domain = module.shared.shared_container_app_environment_default_domain
 
   # Container Images
   frontend_image     = var.frontend_image
@@ -176,11 +150,13 @@ module "validator_apps" {
   frontend_app_name = var.frontend_app_name
   backend_app_name  = var.backend_app_name
 
-  # Workload profile configuration - using Dedicated profile for VNet integration
+  # Workload profile configuration
   workload_profile_name = "default"
   workload_profile_type = "D4"
+  
   depends_on = [
-    module.validator_environment
+    module.shared,
+    azurerm_resource_group.validator
   ]
 }
 
@@ -190,7 +166,7 @@ output "shared_resource_group_name" {
 }
 
 output "validator_resource_group_name" {
-  value = length(module.validator_environment) > 0 ? module.validator_environment[0].resource_group_name : ""
+  value = azurerm_resource_group.validator.name
 }
 
 output "app_gateway_public_ip" {
@@ -198,19 +174,21 @@ output "app_gateway_public_ip" {
 }
 
 output "validator_frontend_fqdn" {
-  value = length(module.validator_apps) > 0 ? module.validator_apps[0].frontend_fqdn : ""
+  value = module.validator_apps.frontend_fqdn
 }
 
 output "validator_backend_fqdn" {
-  value = length(module.validator_apps) > 0 ? module.validator_apps[0].backend_fqdn : ""
+  value = module.validator_apps.backend_fqdn
 }
 
-output "container_app_environment_id" {
-  value = length(module.validator_environment) > 0 ? module.validator_environment[0].container_app_environment_id : ""
+output "shared_container_app_environment_id" {
+  description = "ID of the shared Container App Environment"
+  value       = module.shared.shared_container_app_environment_id
 }
 
-output "container_app_environment_name" {
-  value = length(module.validator_environment) > 0 ? module.validator_environment[0].container_app_environment_name : ""
+output "shared_container_app_environment_name" {
+  description = "Name of the shared Container App Environment"
+  value       = module.shared.shared_container_app_environment_name
 }
 
 # VNet Peering from this environment's VNet to the shared global VNet

--- a/main.tf
+++ b/main.tf
@@ -57,10 +57,6 @@ module "dev" {
   shared_resource_group_name    = var.shared_resource_group_name
   validator_resource_group_name = var.validator_resource_group_name
 
-  # Container Apps Environment (left empty; env module fills when creating)
-  container_app_environment_id             = ""
-  container_app_environment_default_domain = ""
-
   # Remote state (guarded for initial plan)
   shared_global_vnet_id             = try(data.terraform_remote_state.shared_global.outputs.vnet_id, "")
   shared_global_vnet_name           = try(data.terraform_remote_state.shared_global.outputs.vnet_name, "")
@@ -74,12 +70,8 @@ module "test" {
   source = "./environments/test"
 
   # Common variables
-  environment        = "test"
-  location           = var.location
-  frontend_image     = var.frontend_image
-  frontend_image_tag = var.frontend_image_tag
-  backend_image      = var.backend_image
-  backend_image_tag  = var.backend_image_tag
+  environment = "test"
+  location    = var.location
 
   # Remote state (guarded for initial plan)
   shared_global_vnet_id             = try(data.terraform_remote_state.shared_global.outputs.vnet_id, "")
@@ -94,12 +86,8 @@ module "prod" {
   source = "./environments/prod"
 
   # Common variables
-  environment        = "prod"
-  location           = var.location
-  frontend_image     = var.frontend_image
-  frontend_image_tag = var.frontend_image_tag
-  backend_image      = var.backend_image
-  backend_image_tag  = var.backend_image_tag
+  environment = "prod"
+  location    = var.location
 
   # Remote state (guarded for initial plan)
   shared_global_vnet_id             = try(data.terraform_remote_state.shared_global.outputs.vnet_id, "")

--- a/modules/shared/main.tf
+++ b/modules/shared/main.tf
@@ -54,4 +54,66 @@ resource "azurerm_subnet" "validator" {
   }
 }
 
+# Create tool subnet for shared Container App Environment
+# Note: Container Apps require at least /23 subnet size (512 IPs)
+resource "azurerm_subnet" "shared_apps" {
+  name                 = "ismd-shared-apps-subnet-${var.environment}"
+  resource_group_name  = azurerm_resource_group.shared.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.tool_subnet_address_prefix]
+
+  delegation {
+    name = "Microsoft.App.environments"
+    service_delegation {
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+      name    = "Microsoft.App/environments"
+    }
+  }
+}
+
+# Log Analytics Workspace for shared Container App Environment
+resource "azurerm_log_analytics_workspace" "shared" {
+  name                = "ismd-shared-log-workspace-${var.environment}"
+  location            = azurerm_resource_group.shared.location
+  resource_group_name = azurerm_resource_group.shared.name
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+  }
+}
+
+# Shared Container App Environment for all apps in this environment
+resource "azurerm_container_app_environment" "shared" {
+  name                               = "ismd-shared-environment-${var.environment}"
+  location                           = azurerm_resource_group.shared.location
+  resource_group_name                = azurerm_resource_group.shared.name
+  log_analytics_workspace_id         = azurerm_log_analytics_workspace.shared.id
+  infrastructure_subnet_id           = azurerm_subnet.shared_apps.id
+  infrastructure_resource_group_name = "ME_ismd-shared-environment-${var.environment}_${azurerm_resource_group.shared.name}_${var.location}"
+  internal_load_balancer_enabled     = false
+
+  zone_redundancy_enabled = var.environment == "prod"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  workload_profile {
+    name                  = "default"
+    workload_profile_type = var.workload_profile_type
+    minimum_count         = var.workload_profile_min_count
+    maximum_count         = var.workload_profile_max_count
+  }
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+  }
+}
+
 # Outputs are defined in outputs.tf

--- a/modules/shared/outputs.tf
+++ b/modules/shared/outputs.tf
@@ -19,3 +19,28 @@ output "validator_subnet_id" {
   description = "The ID of the validator subnet"
   value       = azurerm_subnet.validator.id
 }
+
+output "shared_apps_subnet_id" {
+  description = "The ID of the shared apps subnet"
+  value       = azurerm_subnet.shared_apps.id
+}
+
+output "shared_container_app_environment_id" {
+  description = "The ID of the shared Container App Environment"
+  value       = azurerm_container_app_environment.shared.id
+}
+
+output "shared_container_app_environment_name" {
+  description = "The name of the shared Container App Environment"
+  value       = azurerm_container_app_environment.shared.name
+}
+
+output "shared_container_app_environment_default_domain" {
+  description = "The default domain of the shared Container App Environment"
+  value       = azurerm_container_app_environment.shared.default_domain
+}
+
+output "shared_log_analytics_workspace_id" {
+  description = "The ID of the shared Log Analytics Workspace"
+  value       = azurerm_log_analytics_workspace.shared.id
+}

--- a/modules/shared/variables.tf
+++ b/modules/shared/variables.tf
@@ -30,3 +30,27 @@ variable "validator_subnet_address_prefix" {
   type        = string
   default     = "10.0.2.0/23"
 }
+
+variable "tool_subnet_address_prefix" {
+  description = "Address prefix for the tool subnet (/23 minimum for Container Apps)"
+  type        = string
+  default     = "10.0.4.0/23"
+}
+
+variable "workload_profile_type" {
+  description = "Workload profile type for the shared Container App Environment"
+  type        = string
+  default     = "D4"
+}
+
+variable "workload_profile_min_count" {
+  description = "Minimum number of instances for the workload profile"
+  type        = number
+  default     = 1
+}
+
+variable "workload_profile_max_count" {
+  description = "Maximum number of instances for the workload profile"
+  type        = number
+  default     = 3
+}

--- a/modules/shared_global/appgw_validator_config.tf
+++ b/modules/shared_global/appgw_validator_config.tf
@@ -171,18 +171,6 @@ locals {
           backend_http_settings_name = "validator-${env}-be-http-settings"
         },
         {
-          name                       = "swagger-ui-index-rule-${env}"
-          paths                      = ["/swagger-ui", "/swagger-ui/"]
-          backend_address_pool_name  = "validator-${env}-be-pool"
-          backend_http_settings_name = "validator-${env}-be-swagger-ui-http-settings"
-        },
-        {
-          name                       = "validator-swagger-ui-index-rule-${env}"
-          paths                      = ["/validator/swagger-ui", "/validator/swagger-ui/", "/validator/swagger-ui/index.html"]
-          backend_address_pool_name  = "validator-${env}-be-pool"
-          backend_http_settings_name = "validator-${env}-be-swagger-ui-http-settings"
-        },
-        {
           name                       = "validator-api-docs-rule-${env}"
           paths                      = ["/validator/api-docs", "/validator/api-docs/*"]
           backend_address_pool_name  = "validator-${env}-be-pool"
@@ -191,6 +179,12 @@ locals {
         {
           name                       = "validator-v3-api-docs-rule-${env}"
           paths                      = ["/validator/v3/*"]
+          backend_address_pool_name  = "validator-${env}-be-pool"
+          backend_http_settings_name = "validator-${env}-be-pass-http-settings"
+        },
+        {
+          name                       = "validator-swagger-ui-rule-${env}"
+          paths                      = ["/validator/swagger-ui/*"]
           backend_address_pool_name  = "validator-${env}-be-pool"
           backend_http_settings_name = "validator-${env}-be-pass-http-settings"
         },

--- a/modules/validator_apps/backend.tf
+++ b/modules/validator_apps/backend.tf
@@ -89,4 +89,10 @@ resource "azurerm_container_app" "backend" {
     Location    = var.location
     SharedRG    = var.shared_resource_group_name
   }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image
+    ]
+  }
 }

--- a/modules/validator_apps/frontend.tf
+++ b/modules/validator_apps/frontend.tf
@@ -57,4 +57,10 @@ resource "azurerm_container_app" "frontend" {
     Location    = var.location
     SharedRG    = var.shared_resource_group_name
   }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image
+    ]
+  }
 }


### PR DESCRIPTION
Major architectural changes:
- Migrate to shared Container App Environment per environment
- Decouple image deployments from infrastructure management
- Add lifecycle ignore_changes for container images in Terraform
- Update workflows to use az containerapp update directly

Infrastructure changes:
- Add shared module for consolidated Container App Environment
- Add tool subnet for upcoming tool apps
- Update terraform.yml to manual-only triggers
- Remove repository_dispatch triggers and handlers
- Clean up terraform-shared-global.yml

Backend/Frontend workflow changes:
- Add environment declarations to all deploy jobs
- Add/update image validation jobs
- Remove finalize-deployment jobs
- Remove repository_dispatch triggers
- Add direct az containerapp update commands

Frontend hostname change:
- Simplified, fix for frontend accessing BE api