### PR TITLE
ci(security): add Trivy reusable scan, align pins, infra finishing touches

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -39,7 +39,7 @@ jobs:
     
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
 
       - name: Azure Login
         uses: azure/login@v3
@@ -47,7 +47,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0" # Specify version matching your local/lock
           terraform_wrapper: false
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
 
       - name: Azure Login
         uses: azure/login@v3
@@ -98,7 +98,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9.0"
           terraform_wrapper: false

--- a/.github/workflows/terraform-shared-global.yml
+++ b/.github/workflows/terraform-shared-global.yml
@@ -95,10 +95,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.11.3'
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -46,10 +46,10 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6
     
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: '1.11.3'
     

--- a/.github/workflows/trivy-reusable.yml
+++ b/.github/workflows/trivy-reusable.yml
@@ -1,0 +1,88 @@
+name: Reusable Trivy Image Scan
+
+# Reusable Trivy image vulnerability scanner.
+# Called by app repos (frontend, tool-frontend, backend, tool-backend) to scan
+# their published GHCR images. SARIF output is uploaded to the *calling* repo's
+# Security -> Code scanning tab so findings stay scoped per-app.
+#
+# Owned by devops/infra. To change scanner config, severity filters, or actions
+# pins, edit this file and bump the @<ref> in the calling stub workflows.
+
+on:
+  workflow_call:
+    inputs:
+      image_ref:
+        description: 'Full GHCR image reference to scan, e.g. ghcr.io/datagov-cz/ismd-tool-backend-dev:latest'
+        required: true
+        type: string
+      severity:
+        description: 'Comma-separated severities to report'
+        required: false
+        type: string
+        default: 'CRITICAL,HIGH'
+      ignore_unfixed:
+        description: 'Skip CVEs with no fix available'
+        required: false
+        type: boolean
+        default: true
+      soft_fail:
+        description: 'If true, the workflow does not fail on findings (baseline phase)'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read         # to pull from GHCR
+      security-events: write # to upload SARIF to the caller repo
+
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ inputs.image_ref }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: ${{ inputs.severity }}
+          ignore-unfixed: ${{ inputs.ignore_unfixed }}
+          scanners: vuln
+          exit-code: ${{ inputs.soft_fail && '0' || '1' }}
+        env:
+          # Use trivy-db proxy to avoid GHCR rate limits on the public DB image
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+
+      - name: Upload SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image
+
+      - name: Also run a human-readable scan (logs only)
+        if: always()
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ inputs.image_ref }}
+          format: table
+          severity: ${{ inputs.severity }}
+          ignore-unfixed: ${{ inputs.ignore_unfixed }}
+          scanners: vuln
+          exit-code: '0'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 This repository contains Terraform configurations for managing Azure Container Apps infrastructure with Application Gateway across multiple environments (dev, test, prod).
 
+## Common Gotchas
+
+> Read this before your first `terraform plan` — these are the things that have actually caught us out.
+
+- **`load_env_vars.sh` must be sourced, not executed.** Running `./load_env_vars.sh dev` does nothing useful — env vars get set in a subshell and disappear immediately. Use one of these:
+  ```bash
+  source load_env_vars.sh dev    # bash
+  . ./load_env_vars.sh dev       # bash (shorthand)
+  . .\load_env_vars.ps1 dev      # PowerShell
+  ```
+  Symptom if you forget: `terraform plan` fails with `expected "administrator_password" to not be an empty string` (or similar empty-var errors).
+
+- **PowerShell and WSL bash have separate environments.** Sourcing the loader in PowerShell does not propagate vars to your WSL bash session. You must source the appropriate script in whichever shell you actually run `terraform` from.
+
+- **Verify env vars before planning:**
+  ```bash
+  env | grep TF_VAR_
+  ```
+  If this is empty, you forgot to source the loader.
+
+- **Workspace must match the environment.** The loader handles this automatically, but if you run `terraform workspace select` manually, make sure you're on the right one (`dev` / `test` / `prod`) before planning or applying.
+
 ## Architecture Overview
 
 - **Shared Container App Environment**: Consolidated environment for all applications (validator and tool) across dev, test, and prod
@@ -472,7 +494,7 @@ Key variables managed through Terraform across all container apps:
 
 **Validator:**
 - `CORS_ALLOWED_ORIGINS` — allowed origins for the backend
-- `NEXT_PUBLIC_BE_URL` — frontend-to-backend URL
+- `BE_URL` — backend base URL used server-side by Next.js rewrites (BFF pattern, not exposed to browser)
 - `PORT` — container port (8080)
 
 **Tool:**

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,7 +54,7 @@ services:
     pull_policy: always
     environment:
       - NODE_ENV=development
-      - NEXT_PUBLIC_BE_URL=http://localhost:8080
+      - BE_URL=http://ismd-validator-backend:8080/validujeme
     restart: "no"
     ports:
       - "3000:3000"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -46,7 +46,7 @@ services:
     image: ismd-validator-frontend-local
     pull_policy: never
     environment:
-      - NEXT_PUBLIC_BE_URL=localhost:8080
+      - BE_URL=http://ismd-validator-backend:8080/validujeme
       - NODE_ENV=development
     depends_on:
       - ismd-validator-backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@
 #
 # Environment Variables:
 # ---------------------
-# NEXT_PUBLIC_BE_URL: Backend hostname with port (protocol added dynamically by frontend)
+# BE_URL: Backend base URL used server-side by Next.js rewrites (BFF pattern, not exposed to browser)
 # NODE_ENV: Node.js environment (development/production)
 # SPRING_PROFILES_ACTIVE: Spring profile (localhost/development/production)
 #
@@ -69,7 +69,7 @@ services:
     image: ghcr.io/datagov-cz/ismd-validator-frontend:latest
     container_name: ismd-validator-frontend
     environment:
-      - NEXT_PUBLIC_BE_URL=localhost:8080
+      - BE_URL=http://ismd-validator-backend:8080/validujeme
       - NODE_ENV=production
     ports:
       - "3000:3000"

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -1,0 +1,186 @@
+# Security Scanning — Runbook
+
+Scope: Trivy (image CVE scanning) and CodeQL (source SAST) across the four app repos, plus the reusable Trivy workflow owned by this infra repo.
+
+---
+
+## What Runs Where
+
+| Tool | Type | Scans | Owned by | Findings land in |
+|---|---|---|---|---|
+| **Trivy** | Image CVE (SCA) | Built Docker images in GHCR | Infra (reusable) + per-app (stub) | App repo → Security → Code scanning |
+| **CodeQL** | Source SAST | JS/TS, Java source | Per-app | App repo → Security → Code scanning |
+| **Checkov** | IaC | Terraform in this repo | Infra | This repo → Security → Code scanning |
+
+Checkov is planned but not yet implemented.
+
+---
+
+## File Inventory
+
+| Repo | File | Purpose |
+|---|---|---|
+| `ismd-infrastructure` | `.github/workflows/trivy-reusable.yml` | Reusable Trivy scanner. Single source of truth for scanner config. |
+| `ismd-validator-frontend` | `.github/workflows/trivy.yml` | Stub — calls reusable for validator-frontend images |
+| `ismd-validator-frontend` | `.github/workflows/codeql.yml` | CodeQL JS/TS |
+| `ismd-tool-frontend` | `.github/workflows/trivy.yml` | Stub — tool-frontend images |
+| `ismd-tool-frontend` | `.github/workflows/codeql.yml` | CodeQL JS/TS |
+| `ismd-validator-backend` | `.github/workflows/trivy.yml` | Stub — validator-backend images |
+| `ismd-validator-backend` | `.github/workflows/codeql.yml` | CodeQL Java (replicates mvnw build incl. common library) |
+| `ismd-tool-backend` | `.github/workflows/trivy.yml` | Stub — tool-backend images |
+| `ismd-tool-backend` | `.github/workflows/codeql.yml` | CodeQL Java |
+
+---
+
+## Trivy — Triggers
+
+Per-app stubs wire up the following triggers. The scanner logic itself is centralized in the reusable.
+
+| Event | `scan-dev` job | `scan-main` job | Reason |
+|---|---|---|---|
+| `Build Docker on Dev` succeeds | ✅ | ❌ | New dev image scanned within minutes |
+| `Build Docker on Main` succeeds | ❌ | ✅ | New prod-bound image scanned within minutes |
+| Schedule (Mondays 07:00 UTC) | ✅ | ✅ | CVE-feed drift — new CVEs may land for unchanged images |
+| Manual dispatch (`dev`) | ✅ | ❌ | Targeted re-scan |
+| Manual dispatch (`main`) | ❌ | ✅ | Targeted re-scan |
+| Manual dispatch (`both`) | ✅ | ✅ | Full re-scan |
+
+**Image taxonomy** (per `reusable-docker-build.yml` in each app repo):
+
+- `dev` branch → `ghcr.io/datagov-cz/<repo>-dev:latest` → deployed to dev
+- `main` branch → `ghcr.io/datagov-cz/<repo>:latest` → deployed to test, then prod
+
+Both variants are scanned. Findings are deduplicated in the Security tab per `category:` — Trivy uses `trivy-image`.
+
+### Important quirk
+
+`workflow_run` triggers **only fire when the workflow file lives on the repo's default branch**. On merge into `dev`, the new `trivy.yml` won't react to `Build Docker on *` events until it's also on `main`. Cron and manual dispatch work either way.
+
+---
+
+## CodeQL — Triggers
+
+- `push` to `dev` or `main`
+- `pull_request` targeting `dev` or `main`
+- Schedule: Mondays 06:00 UTC
+
+CodeQL scans source, not images, so branch is the right axis (not image variant).
+
+---
+
+## Blocking vs Non-Blocking
+
+**Default everywhere: non-blocking.** Findings populate the Security tab; workflows always succeed. This is the right baseline — flipping to blocking before you have a clean baseline just deadlocks PRs on pre-existing issues.
+
+### Trivy — How to Make a Scan Blocking
+
+**Option A — One-off blocking run (manual, for testing a specific fix):**
+
+1. Go to the app repo → Actions → **Trivy Image Scan** → **Run workflow**.
+2. Pick `image_variant` (`dev`, `main`, or `both`).
+3. **Uncheck** the `soft_fail` checkbox.
+4. Run. Scan fails the job on any HIGH/CRITICAL finding.
+
+The `soft_fail` input defaults to checked (non-blocking). Auto-triggered runs (`workflow_run`, `schedule`) **always** run non-blocking regardless of this input — by design, so a fresh CVE disclosure doesn't silently turn every deploy red overnight.
+
+**Option B — Permanent blocking for all repos (via reusable workflow default):**
+
+Edit [`../.github/workflows/trivy-reusable.yml`](../.github/workflows/trivy-reusable.yml), change the default on the `soft_fail` input:
+
+```yaml
+soft_fail:
+  required: false
+  type: boolean
+  default: false    # <-- was true
+```
+
+This flips **all four app repos** at once, on their next scheduled or workflow_run-triggered scan. Only do this once Security tab baselines are clean (zero open findings across all repos), otherwise all four repos will have red Trivy checks simultaneously.
+
+### CodeQL — How to Make a Scan Blocking
+
+CodeQL's `analyze` action never fails the job on findings — it uploads SARIF and exits green. Blocking is controlled **at the repo level, not in the workflow file**, via branch protection:
+
+1. Repo → Settings → Branches → Add (or edit) rule for `main` (and/or `dev`).
+2. Enable **Require status checks to pass before merging**.
+3. Add `Analyze (javascript-typescript)` (for frontends) or `Analyze (java)` (for backends) as a required check.
+4. Optionally enable **Require branches to be up to date** and **Include administrators**.
+
+From that moment, PRs introducing new CodeQL findings fail the required check and can't be merged. Existing findings on the base branch remain visible in the Security tab but don't block — only new code introducing new findings does.
+
+Recommended rollout: set this up **after** the baseline is triaged (existing findings either fixed or dismissed with reason in the Security tab UI).
+
+### Summary Table
+
+| Tool | Default | One-off blocking | Permanent blocking |
+|---|---|---|---|
+| Trivy | Non-blocking | Manual dispatch with `soft_fail` unchecked | Flip default in `trivy-reusable.yml` |
+| CodeQL | Non-blocking (job always green) | N/A — action doesn't fail | Branch protection rule: require `Analyze` check |
+
+---
+
+## Operating Procedures
+
+### Triaging a new Trivy finding
+
+1. Open the app repo → Security → Code scanning → filter by `trivy-image`.
+2. Click the finding. Note the package, installed version, fix version, severity.
+3. Decide:
+   - **Base-image finding** (alpine/musl/openssl/libpng/zlib etc.) → devops fixes in the Dockerfile. Usually a base tag bump.
+   - **App-dep finding** (axios, tomcat, spring-core, etc.) → file an issue for the FE/BE team with the finding link.
+   - **False positive / inapplicable** → dismiss with reason in the UI (dismissals persist across runs).
+
+### Triaging a new CodeQL finding
+
+1. Open the app repo → Security → Code scanning → filter by language.
+2. Click the finding. CodeQL shows the exact file/line and a data flow if applicable.
+3. Decide:
+   - **Real bug** → file an issue for the owning team.
+   - **Won't fix / test code / intentional** → dismiss with reason.
+
+### Rolling the reusable Trivy workflow forward
+
+The stub workflows pin to `@dev` (matches existing `terraform.yml` convention). When you edit `trivy-reusable.yml`:
+
+- Push to `dev` → stubs pick up changes immediately.
+- Once stable, consider switching stubs to a version tag (`@v1`) for explicit rollouts.
+
+### When a team fixes a CVE and redeploys
+
+1. Team merges fix → builds new image → `Build Docker on *` succeeds.
+2. `workflow_run` fires → Trivy rescans the fresh image within minutes.
+3. Security tab auto-dismisses findings that no longer appear in the new scan (by CVE ID + package).
+4. If a finding doesn't auto-clear, verify the installed version in the new image actually changed — it may be a sibling dep transitively pulling in the old version.
+
+---
+
+## Local Scanning (Devops Only)
+
+### Trivy (ad-hoc recon)
+
+Run under WSL bash with Docker Desktop active:
+
+```bash
+for img in ismd-tool-backend-dev ismd-tool-frontend-dev ismd-validator-backend-dev ismd-validator-frontend-dev; do
+  docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$HOME/.cache/trivy:/root/.cache/" \
+    aquasec/trivy:latest image \
+    --severity CRITICAL,HIGH --ignore-unfixed --scanners vuln --quiet \
+    "ghcr.io/datagov-cz/${img}:latest" > "${img}.txt" 2>&1
+done
+```
+
+GHCR images are public — no auth needed.
+
+### CodeQL (not installed locally)
+
+CodeQL is CI-only in this project. The CLI bundle is ~700 MB and Java DB creation runs a full Maven build. Use the GitHub Actions runs for CodeQL results; the Security tab dedupes and formats better than local SARIF anyway.
+
+---
+
+## Known Limitations / Gotchas
+
+- **Trivy scans `:latest` only.** If a specific versioned image needs ad-hoc scanning, dispatch-run with a local edit or pull the tagged image and run Trivy manually.
+- **`workflow_run` default-branch requirement** (see above) — first rollout requires merging to the default branch before auto-trigger works.
+- **Trivy DB rate limits on GHCR** — mitigated by pulling DB from AWS public ECR (`TRIVY_DB_REPOSITORY` env in the reusable).
+- **CodeQL Java build reuses `mvnw`** — requires `GITHUB_TOKEN` with `packages: read` (already set in the workflows) to pull `ismd-validator-common` from GH Packages.

--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -1,4 +1,5 @@
-environment                   = "dev"
+# Dev environment configuration
+
 location                      = "germanywestcentral"
 shared_resource_group_name    = "ismd-shared-dev"
 validator_resource_group_name = "ismd-validator-dev"
@@ -17,7 +18,7 @@ tool_backend_image      = "ghcr.io/datagov-cz/ismd-tool-backend-dev"
 tool_backend_image_tag  = "0.0.1-a9a5d5b"
 
 # App Gateway - DEV hostname (HTTPS)
-app_gateway_hostname = "oha03.dia.gov.cz"
+app_gateway_hostname   = "oha03.dia.gov.cz"
 tool_keycloak_hostname = "oha03.dia.gov.cz"
 
 deploy_tool_apps = true

--- a/modules/shared_global/appgw_validator_config.tf
+++ b/modules/shared_global/appgw_validator_config.tf
@@ -6,72 +6,44 @@ locals {
   validator_environments = ["dev", "test", "prod"]
 
   # Backend Address Pools
-  validator_backend_pools = flatten([
-    for env in local.validator_environments : [
-      {
-        name  = "validator-${env}-fe-pool"
-        fqdns = env == "dev" ? (var.frontend_fqdn != "" ? [var.frontend_fqdn] : (var.container_app_environment_domain_dev != "" ? ["${var.frontend_app_name}-dev.${var.container_app_environment_domain_dev}"] : [])) : env == "test" ? (var.frontend_fqdn_test != "" ? [var.frontend_fqdn_test] : (var.container_app_environment_domain_test != "" ? ["${var.frontend_app_name}-test.${var.container_app_environment_domain_test}"] : [])) : (var.frontend_fqdn_prod != "" ? [var.frontend_fqdn_prod] : (var.container_app_environment_domain_prod != "" ? ["${var.frontend_app_name}-prod.${var.container_app_environment_domain_prod}"] : []))
-      },
-      {
-        name  = "validator-${env}-be-pool"
-        fqdns = env == "dev" ? (var.backend_fqdn != "" ? [var.backend_fqdn] : (var.container_app_environment_domain_dev != "" ? ["${var.backend_app_name}-dev.${var.container_app_environment_domain_dev}"] : [])) : env == "test" ? (var.backend_fqdn_test != "" ? [var.backend_fqdn_test] : (var.container_app_environment_domain_test != "" ? ["${var.backend_app_name}-test.${var.container_app_environment_domain_test}"] : [])) : (var.backend_fqdn_prod != "" ? [var.backend_fqdn_prod] : (var.container_app_environment_domain_prod != "" ? ["${var.backend_app_name}-prod.${var.container_app_environment_domain_prod}"] : []))
-      }
-    ]
-  ])
+  # Note: be-pool removed — validator backend now has internal ingress only (BFF pattern).
+  # All traffic routes through the Next.js frontend; App Gateway only needs fe-pool.
+  validator_backend_pools = [
+    for env in local.validator_environments : {
+      name  = "validator-${env}-fe-pool"
+      fqdns = env == "dev" ? (var.frontend_fqdn != "" ? [var.frontend_fqdn] : (var.container_app_environment_domain_dev != "" ? ["${var.frontend_app_name}-dev.${var.container_app_environment_domain_dev}"] : [])) : env == "test" ? (var.frontend_fqdn_test != "" ? [var.frontend_fqdn_test] : (var.container_app_environment_domain_test != "" ? ["${var.frontend_app_name}-test.${var.container_app_environment_domain_test}"] : [])) : (var.frontend_fqdn_prod != "" ? [var.frontend_fqdn_prod] : (var.container_app_environment_domain_prod != "" ? ["${var.frontend_app_name}-prod.${var.container_app_environment_domain_prod}"] : []))
+    }
+  ]
 
   # Health Probes
-  validator_probes = flatten([
-    for env in local.validator_environments : [
-      {
-        name                                      = "validator-${env}-fe-probe"
-        protocol                                  = "Http"
-        path                                      = "/validujeme"
-        interval                                  = 30
-        timeout                                   = 30
-        unhealthy_threshold                       = 3
-        pick_host_name_from_backend_http_settings = true
-        match_status_codes                        = ["200-399"]
-      },
-      {
-        name                                      = "validator-${env}-be-probe"
-        protocol                                  = "Http"
-        path                                      = "/validujeme/actuator/health"
-        interval                                  = 30
-        timeout                                   = 30
-        unhealthy_threshold                       = 3
-        pick_host_name_from_backend_http_settings = true
-        match_status_codes                        = ["200-399"]
-      }
-    ]
-  ])
+  # Note: be-probe removed — backend is internal only, unreachable from App Gateway.
+  validator_probes = [
+    for env in local.validator_environments : {
+      name                                      = "validator-${env}-fe-probe"
+      protocol                                  = "Http"
+      path                                      = "/validujeme"
+      interval                                  = 30
+      timeout                                   = 30
+      unhealthy_threshold                       = 3
+      pick_host_name_from_backend_http_settings = true
+      match_status_codes                        = ["200-399"]
+    }
+  ]
 
   # Backend HTTP Settings
-  validator_backend_http_settings = flatten([
-    for env in local.validator_environments : [
-      # Frontend settings (Pass-through path, no override)
-      {
-        name                                = "validator-${env}-fe-http-settings"
-        cookie_based_affinity               = "Disabled"
-        port                                = 80
-        protocol                            = "Http"
-        request_timeout                     = 60
-        probe_name                          = "validator-${env}-fe-probe"
-        pick_host_name_from_backend_address = true
-        path                                = null # Do not rewrite path! App expects /validujeme prefix
-      },
-      # Backend API settings (Pass-through path, no override)
-      {
-        name                                = "validator-${env}-be-http-settings"
-        cookie_based_affinity               = "Disabled"
-        port                                = 80
-        protocol                            = "Http"
-        request_timeout                     = 60
-        probe_name                          = "validator-${env}-be-probe"
-        pick_host_name_from_backend_address = true
-        path                                = null # Do not rewrite path! App expects /validujeme/api prefix
-      },
-    ]
-  ])
+  # Note: be-http-settings removed — backend is internal only, all traffic goes through frontend.
+  validator_backend_http_settings = [
+    for env in local.validator_environments : {
+      name                                = "validator-${env}-fe-http-settings"
+      cookie_based_affinity               = "Disabled"
+      port                                = 80
+      protocol                            = "Http"
+      request_timeout                     = 60
+      probe_name                          = "validator-${env}-fe-probe"
+      pick_host_name_from_backend_address = true
+      path                                = null # Do not rewrite path — app expects /validujeme prefix
+    }
+  ]
 
   # HTTP Listeners (hostname-based)
   validator_http_listeners = flatten([
@@ -144,13 +116,9 @@ locals {
       default_backend_address_pool_name   = null
       default_backend_http_settings_name  = null
       default_redirect_configuration_name = "redirect-root-to-validujeme-${env}"
+      # api-rule removed — backend is internal only. All /validujeme/* routes to frontend;
+      # Next.js rewrites proxy /validujeme/api/* → backend server-side.
       path_rules = concat([
-        {
-          name                       = "api-rule-${env}"
-          paths                      = ["/validujeme/api/*", "/validujeme/api"]
-          backend_address_pool_name  = "validator-${env}-be-pool"
-          backend_http_settings_name = "validator-${env}-be-http-settings"
-        },
         {
           name                       = "frontend-rule-${env}"
           paths                      = ["/validujeme/*", "/validujeme"]

--- a/modules/tool_apps/backend.tf
+++ b/modules/tool_apps/backend.tf
@@ -47,6 +47,7 @@ resource "azurerm_container_app" "backend" {
 
   template {
     min_replicas = 1
+    max_replicas = 1 # Pinned to singleton — see TODO §12 for reasoning (avoids DB connection pool exhaustion, no concurrency hardening needed)
     container {
       name   = "ismd-tool-backend-${var.environment}"
       image  = "${var.backend_image}:${var.backend_image_tag}"

--- a/modules/validator_apps/backend.tf
+++ b/modules/validator_apps/backend.tf
@@ -26,24 +26,14 @@ resource "azurerm_container_app" "backend" {
   }
 
   ingress {
-    external_enabled = true
+    # Internal only — all browser traffic goes through Next.js frontend (BFF pattern)
+    external_enabled = false
     target_port      = 8080
     transport        = "auto"
 
     traffic_weight {
       latest_revision = true
       percentage      = 100
-    }
-    allow_insecure_connections = true
-
-    # Restrict ingress to Application Gateway public IP (only when known)
-    dynamic "ip_security_restriction" {
-      for_each = var.app_gateway_public_ip != "" ? [var.app_gateway_public_ip] : []
-      content {
-        name             = "AllowAppGateway"
-        ip_address_range = "${ip_security_restriction.value}/32"
-        action           = "Allow"
-      }
     }
   }
 

--- a/modules/validator_apps/frontend.tf
+++ b/modules/validator_apps/frontend.tf
@@ -19,11 +19,10 @@ resource "azurerm_container_app" "frontend" {
       cpu    = 0.5
       memory = "1Gi"
       env {
-        name = "NEXT_PUBLIC_BE_URL"
-        # Include protocol for compatibility with current frontend (without interceptor)
-        # Use HTTPS for TEST/PROD (accessed via HTTPS), HTTP for DEV (no cert yet)
-        # Path /validujeme is required for App Gateway routing
-        value = var.environment == "dev" ? (var.app_gateway_hostname != "" ? "http://${var.app_gateway_hostname}/validujeme" : "http://${var.app_gateway_public_ip}/validujeme") : (var.app_gateway_hostname != "" ? "https://${var.app_gateway_hostname}/validujeme" : "https://${var.app_gateway_public_ip}/validujeme")
+        # Server-side only — Next.js rewrites proxy /validujeme/api/* → backend internally.
+        # Backend has internal ingress only; never exposed to the browser.
+        name  = "BE_URL"
+        value = "http://${azurerm_container_app.backend.name}/validujeme"
       }
 
       liveness_probe {


### PR DESCRIPTION
Security:
- Add reusable Trivy workflow scanning GHCR images for CRITICAL/HIGH CVEs and uploading SARIF to caller-repo Security tabs. Owned centrally so per-app stubs stay tiny. Non-blocking by default; configurable via soft_fail input. Trivy DB pulled from AWS public ECR to avoid GHCR rate limits.
- Add docs/security-scanning.md operator runbook covering triggers, blocking modes, triage, and local recon.

Workflow hygiene:
- actions/checkout pins aligned to @v6 (was a mix of @v6.0.1 and @v6.0.2 across terraform workflows).
- hashicorp/setup-terraform: @v3 -> @v4 (Node 24 runtime, no workflow changes required).

Infra finishing touches:
- Trim dead App Gateway backend routing (validator/swagger now proxied via frontend).
- Align docker-compose stacks, tfvars examples, and README with the new layout. Tidy validator/tool app module wiring.