### PR TITLE
fix: point FUSEKI_URL to /ismd-tool-dataset instead of /ds

### DIFF
--- a/modules/tool_apps/backend.tf
+++ b/modules/tool_apps/backend.tf
@@ -81,7 +81,7 @@ resource "azurerm_container_app" "backend" {
       }
       env {
         name  = "FUSEKI_URL"
-        value = var.deploy_fuseki ? "https://ismd-tool-fuseki-${var.environment}.internal.${var.container_app_environment_default_domain}/ds" : var.fuseki_url
+        value = var.deploy_fuseki ? "https://ismd-tool-fuseki-${var.environment}.internal.${var.container_app_environment_default_domain}/ismd-tool-dataset" : var.fuseki_url
       }
       env {
         name  = "KEYCLOAK_ISSUER_URI"

--- a/modules/tool_apps/database.tf
+++ b/modules/tool_apps/database.tf
@@ -201,5 +201,5 @@ output "postgres_fqdn" {
 
 output "fuseki_internal_url" {
   description = "Internal URL for Fuseki"
-  value       = var.deploy_fuseki ? "https://ismd-tool-fuseki-${var.environment}.internal.${var.container_app_environment_default_domain}/ds" : var.fuseki_url
+  value       = var.deploy_fuseki ? "https://ismd-tool-fuseki-${var.environment}.internal.${var.container_app_environment_default_domain}/ismd-tool-dataset" : var.fuseki_url
 }

--- a/modules/tool_apps/database.tf
+++ b/modules/tool_apps/database.tf
@@ -42,6 +42,18 @@ resource "azurerm_postgresql_flexible_server" "tool" {
   }
 }
 
+# Allow the unaccent extension at the server level so the application can
+# CREATE EXTENSION unaccent in the ismd_schema. The repositories in
+# ismd-tool-backend (ConceptMetadataRepository, OntologyMetadataRepository)
+# call ismd_schema.unaccent(...) for diacritic-insensitive search over
+# Czech text — without this, those queries fail at runtime.
+resource "azurerm_postgresql_flexible_server_configuration" "unaccent" {
+  count     = var.deploy_postgres ? 1 : 0
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.tool[0].id
+  value     = "UNACCENT"
+}
+
 # Create the application database
 resource "azurerm_postgresql_flexible_server_database" "tool" {
   count     = var.deploy_postgres ? 1 : 0


### PR DESCRIPTION
The fuseki assembler config defines the dataset name as "ismd-tool-dataset", so the deployed service exposes endpoints under that path, not /ds. Updates both the backend container env var and the fuseki_internal_url output to match. Pairs with the ismd-tool-backend change that bakes fuseki-config.ttl into the image so auto-discovery loads it on startup.