### PR TITLE
feat(apps): expose SITE_PREVIEW_SECRET to validator + tool frontends

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -22,8 +22,8 @@ module "validator_apps" {
   resource_group_name = var.validator_resource_group_name
 
   # Required by the module
-  shared_resource_group_name               = var.shared_resource_group_name
-  container_app_environment_id             = module.shared.shared_container_app_environment_id
+  shared_resource_group_name   = var.shared_resource_group_name
+  container_app_environment_id = module.shared.shared_container_app_environment_id
   # Container Images
   frontend_image     = var.frontend_image
   frontend_image_tag = var.frontend_image_tag
@@ -43,6 +43,10 @@ module "validator_apps" {
 
   # Workload profile configuration
   workload_profile_name = "default"
+
+  # Frontend gating (live | coming_soon | maintenance)
+  site_status         = var.validator_site_status
+  site_preview_secret = var.validator_site_preview_secret
 
   depends_on = [
     module.shared,
@@ -102,6 +106,10 @@ module "tool_apps" {
   # Frontend auth
   nextauth_secret = var.tool_nextauth_secret
   tool_base_path  = var.tool_base_path
+
+  # Frontend gating (live | coming_soon | maintenance)
+  site_status         = var.tool_site_status
+  site_preview_secret = var.tool_site_preview_secret
 
   # Keycloak / CAAIS
   deploy_keycloak         = var.tool_deploy_keycloak

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -180,6 +180,32 @@ variable "tool_base_path" {
   default     = "/popisujeme"
 }
 
+variable "tool_site_status" {
+  description = "Frontend gating mode for the Tool app: 'live', 'coming_soon', or 'maintenance'."
+  type        = string
+  default     = "live"
+}
+
+variable "validator_site_status" {
+  description = "Frontend gating mode for the Validator app: 'live', 'coming_soon', or 'maintenance'."
+  type        = string
+  default     = "live"
+}
+
+variable "tool_site_preview_secret" {
+  description = "Bypass secret for the Tool app's Coming Soon / Maintenance gate. Empty disables the bypass."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "validator_site_preview_secret" {
+  description = "Bypass secret for the Validator app's Coming Soon / Maintenance gate. Empty disables the bypass."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "tool_deploy_keycloak" {
   description = "Whether to deploy Keycloak in tool apps"
   type        = bool

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -23,8 +23,8 @@ module "validator_apps" {
   resource_group_name = var.validator_resource_group_name
 
   # Required by the module
-  shared_resource_group_name               = var.shared_resource_group_name
-  container_app_environment_id             = module.shared.shared_container_app_environment_id
+  shared_resource_group_name   = var.shared_resource_group_name
+  container_app_environment_id = module.shared.shared_container_app_environment_id
   # Container Images
   frontend_image     = var.frontend_image
   frontend_image_tag = var.frontend_image_tag
@@ -44,6 +44,10 @@ module "validator_apps" {
 
   # Workload profile configuration
   workload_profile_name = "default"
+
+  # Frontend gating (live | coming_soon | maintenance)
+  site_status         = var.validator_site_status
+  site_preview_secret = var.validator_site_preview_secret
 
   depends_on = [
     module.shared,
@@ -103,6 +107,10 @@ module "tool_apps" {
   # Frontend auth
   nextauth_secret = var.tool_nextauth_secret
   tool_base_path  = var.tool_base_path
+
+  # Frontend gating (live | coming_soon | maintenance)
+  site_status         = var.tool_site_status
+  site_preview_secret = var.tool_site_preview_secret
 
   # Keycloak / CAAIS
   deploy_keycloak         = var.tool_deploy_keycloak

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -180,6 +180,32 @@ variable "tool_base_path" {
   default     = "/popisujeme"
 }
 
+variable "tool_site_status" {
+  description = "Frontend gating mode for the Tool app: 'live', 'coming_soon', or 'maintenance'."
+  type        = string
+  default     = "coming_soon"
+}
+
+variable "validator_site_status" {
+  description = "Frontend gating mode for the Validator app: 'live', 'coming_soon', or 'maintenance'."
+  type        = string
+  default     = "coming_soon"
+}
+
+variable "tool_site_preview_secret" {
+  description = "Bypass secret for the Tool app's Coming Soon / Maintenance gate. Empty disables the bypass."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "validator_site_preview_secret" {
+  description = "Bypass secret for the Validator app's Coming Soon / Maintenance gate. Empty disables the bypass."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "tool_deploy_keycloak" {
   description = "Whether to deploy Keycloak in tool apps"
   type        = bool

--- a/environments/test/main.tf
+++ b/environments/test/main.tf
@@ -23,8 +23,8 @@ module "validator_apps" {
   resource_group_name = var.validator_resource_group_name
 
   # Required by the module
-  shared_resource_group_name               = var.shared_resource_group_name
-  container_app_environment_id             = module.shared.shared_container_app_environment_id
+  shared_resource_group_name   = var.shared_resource_group_name
+  container_app_environment_id = module.shared.shared_container_app_environment_id
   # Container Images
   frontend_image     = var.frontend_image
   frontend_image_tag = var.frontend_image_tag
@@ -44,6 +44,10 @@ module "validator_apps" {
 
   # Workload profile configuration
   workload_profile_name = "default"
+
+  # Frontend gating (live | coming_soon | maintenance)
+  site_status         = var.validator_site_status
+  site_preview_secret = var.validator_site_preview_secret
 
   depends_on = [
     module.shared,
@@ -103,6 +107,10 @@ module "tool_apps" {
   # Frontend auth
   nextauth_secret = var.tool_nextauth_secret
   tool_base_path  = var.tool_base_path
+
+  # Frontend gating (live | coming_soon | maintenance)
+  site_status         = var.tool_site_status
+  site_preview_secret = var.tool_site_preview_secret
 
   # Keycloak / CAAIS
   deploy_keycloak         = var.tool_deploy_keycloak

--- a/environments/test/variables.tf
+++ b/environments/test/variables.tf
@@ -180,6 +180,32 @@ variable "tool_base_path" {
   default     = "/popisujeme"
 }
 
+variable "tool_site_status" {
+  description = "Frontend gating mode for the Tool app: 'live', 'coming_soon', or 'maintenance'."
+  type        = string
+  default     = "coming_soon"
+}
+
+variable "validator_site_status" {
+  description = "Frontend gating mode for the Validator app: 'live', 'coming_soon', or 'maintenance'."
+  type        = string
+  default     = "coming_soon"
+}
+
+variable "tool_site_preview_secret" {
+  description = "Bypass secret for the Tool app's Coming Soon / Maintenance gate. Empty disables the bypass."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "validator_site_preview_secret" {
+  description = "Bypass secret for the Validator app's Coming Soon / Maintenance gate. Empty disables the bypass."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "tool_deploy_keycloak" {
   description = "Whether to deploy Keycloak in tool apps"
   type        = bool

--- a/modules/shared_global/appgw_resource.tf
+++ b/modules/shared_global/appgw_resource.tf
@@ -270,6 +270,19 @@ resource "azurerm_application_gateway" "appgw" {
     }
   }
 
+  # ========================================
+  # Custom Error Pages
+  # ========================================
+  custom_error_configuration {
+    status_code           = "HttpStatus502"
+    custom_error_page_url = "${azurerm_storage_account.error_pages.primary_web_endpoint}502.html"
+  }
+
+  custom_error_configuration {
+    status_code           = "HttpStatus403"
+    custom_error_page_url = "${azurerm_storage_account.error_pages.primary_web_endpoint}403.html"
+  }
+
   tags = {
     environment = "shared"
   }

--- a/modules/shared_global/error_pages.tf
+++ b/modules/shared_global/error_pages.tf
@@ -1,0 +1,43 @@
+# Storage Account for App Gateway custom error pages.
+# Static website hosting serves the HTML at a public HTTPS URL that the
+# App Gateway custom_error_configuration blocks can reference.
+
+resource "azurerm_storage_account" "error_pages" {
+  name                     = "ismdstaticerrorpages"
+  resource_group_name      = azurerm_resource_group.shared_global.name
+  location                 = azurerm_resource_group.shared_global.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+  min_tls_version          = "TLS1_2"
+
+  static_website {
+    index_document     = "502.html"
+    error_404_document = "502.html"
+  }
+
+  tags = {
+    ManagedBy = "Terraform"
+    Purpose   = "App Gateway error pages"
+  }
+}
+
+resource "azurerm_storage_blob" "error_502" {
+  name                   = "502.html"
+  storage_account_name   = azurerm_storage_account.error_pages.name
+  storage_container_name = "$web"
+  type                   = "Block"
+  content_type           = "text/html"
+  source                 = "${path.module}/../../static-pages/502.html"
+  content_md5            = filemd5("${path.module}/../../static-pages/502.html")
+}
+
+resource "azurerm_storage_blob" "error_403" {
+  name                   = "403.html"
+  storage_account_name   = azurerm_storage_account.error_pages.name
+  storage_container_name = "$web"
+  type                   = "Block"
+  content_type           = "text/html"
+  source                 = "${path.module}/../../static-pages/403.html"
+  content_md5            = filemd5("${path.module}/../../static-pages/403.html")
+}

--- a/modules/tool_apps/backend.tf
+++ b/modules/tool_apps/backend.tf
@@ -63,7 +63,7 @@ resource "azurerm_container_app" "backend" {
         value = "8080"
       }
       env {
-        name  = "SPRING_PROFILES_ACTIVE"
+        name = "SPRING_PROFILES_ACTIVE"
         # TODO: switch test back to "stage" once stage profile reads env vars (FUSEKI_URL, CORS_ALLOWED_ORIGINS)
         value = var.environment == "prod" ? "production" : "dev"
       }

--- a/modules/tool_apps/database.tf
+++ b/modules/tool_apps/database.tf
@@ -97,6 +97,7 @@ resource "azurerm_storage_account" "fuseki" {
   location                 = var.location
   account_tier             = "Standard"
   account_replication_type = var.environment == "prod" ? "GRS" : "LRS"
+  min_tls_version          = "TLS1_2"
 
   tags = {
     Environment = var.environment

--- a/modules/tool_apps/frontend.tf
+++ b/modules/tool_apps/frontend.tf
@@ -57,6 +57,17 @@ resource "azurerm_container_app" "frontend" {
         name        = "NEXTAUTH_SECRET"
         secret_name = "nextauth-secret"
       }
+      env {
+        name  = "SITE_STATUS"
+        value = var.site_status
+      }
+      dynamic "env" {
+        for_each = var.site_preview_secret != "" ? [1] : []
+        content {
+          name        = "SITE_PREVIEW_SECRET"
+          secret_name = "site-preview-secret"
+        }
+      }
 
       liveness_probe {
         transport               = "HTTP"
@@ -68,8 +79,9 @@ resource "azurerm_container_app" "frontend" {
       }
 
       readiness_probe {
-        transport               = "TCP"
+        transport               = "HTTP"
         port                    = 3000
+        path                    = "/popisujeme"
         interval_seconds        = 8
         failure_count_threshold = 30
         success_count_threshold = 1
@@ -94,6 +106,14 @@ resource "azurerm_container_app" "frontend" {
   secret {
     name  = "keycloak-client-secret"
     value = var.keycloak_client_secret
+  }
+
+  dynamic "secret" {
+    for_each = var.site_preview_secret != "" ? [1] : []
+    content {
+      name  = "site-preview-secret"
+      value = var.site_preview_secret
+    }
   }
 
   ingress {

--- a/modules/tool_apps/keycloak.tf
+++ b/modules/tool_apps/keycloak.tf
@@ -36,7 +36,7 @@ resource "azurerm_container_app" "keycloak" {
         "--http-enabled=true",
         "--http-port=8080",
         "--proxy-headers=forwarded"
-      ], local.keycloak_hostname_effective == "" ? [] : [
+        ], local.keycloak_hostname_effective == "" ? [] : [
         "--hostname=${local.keycloak_hostname_effective}",
         "--hostname-admin=${local.keycloak_hostname_effective}"
       ])

--- a/modules/tool_apps/variables.tf
+++ b/modules/tool_apps/variables.tf
@@ -104,3 +104,24 @@ variable "tool_base_path" {
   type        = string
   default     = "/popisujeme"
 }
+
+variable "site_status" {
+  description = "Frontend gating mode. 'live' serves the app normally; 'coming_soon' and 'maintenance' rewrite all traffic to the matching gated page (the Next.js middleware reads this env var)."
+  type        = string
+  default     = "live"
+  validation {
+    condition     = contains(["live", "coming_soon", "maintenance"], var.site_status)
+    error_message = "site_status must be one of: live, coming_soon, maintenance."
+  }
+}
+
+variable "site_preview_secret" {
+  description = "Shared secret for bypassing the Coming Soon / Maintenance gate. When non-empty, visiting any URL with ?nahled=<secret> sets a long-lived bypass cookie. Leave empty to disable the bypass entirely. Must not equal the literal 'ne' (reserved for cookie clearing)."
+  type        = string
+  sensitive   = true
+  default     = ""
+  validation {
+    condition     = var.site_preview_secret != "ne"
+    error_message = "site_preview_secret must not equal the literal 'ne' (reserved for cookie clearing via ?nahled=ne)."
+  }
+}

--- a/modules/validator_apps/frontend.tf
+++ b/modules/validator_apps/frontend.tf
@@ -24,18 +24,31 @@ resource "azurerm_container_app" "frontend" {
         name  = "BE_URL"
         value = "http://${azurerm_container_app.backend.name}/validujeme"
       }
+      env {
+        name  = "SITE_STATUS"
+        value = var.site_status
+      }
+      dynamic "env" {
+        for_each = var.site_preview_secret != "" ? [1] : []
+        content {
+          name        = "SITE_PREVIEW_SECRET"
+          secret_name = "site-preview-secret"
+        }
+      }
 
       liveness_probe {
-        transport               = "TCP"
+        transport               = "HTTP"
         port                    = 3000
+        path                    = "/validujeme"
         interval_seconds        = 10
         failure_count_threshold = 3
         timeout                 = 5
       }
 
       readiness_probe {
-        transport               = "TCP"
+        transport               = "HTTP"
         port                    = 3000
+        path                    = "/validujeme"
         interval_seconds        = 8
         failure_count_threshold = 30
         success_count_threshold = 1
@@ -49,6 +62,14 @@ resource "azurerm_container_app" "frontend" {
         failure_count_threshold = 30
         timeout                 = 3
       }
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.site_preview_secret != "" ? [1] : []
+    content {
+      name  = "site-preview-secret"
+      value = var.site_preview_secret
     }
   }
 

--- a/modules/validator_apps/variables.tf
+++ b/modules/validator_apps/variables.tf
@@ -82,3 +82,24 @@ variable "additional_cors_origins" {
   type        = list(string)
   default     = []
 }
+
+variable "site_status" {
+  description = "Frontend gating mode. 'live' serves the app normally; 'coming_soon' and 'maintenance' rewrite all traffic to the matching gated page (the Next.js middleware reads this env var)."
+  type        = string
+  default     = "live"
+  validation {
+    condition     = contains(["live", "coming_soon", "maintenance"], var.site_status)
+    error_message = "site_status must be one of: live, coming_soon, maintenance."
+  }
+}
+
+variable "site_preview_secret" {
+  description = "Shared secret for bypassing the Coming Soon / Maintenance gate. When non-empty, visiting any URL with ?nahled=<secret> sets a long-lived bypass cookie. Leave empty to disable the bypass entirely. Must not equal the literal 'ne' (reserved for cookie clearing)."
+  type        = string
+  sensitive   = true
+  default     = ""
+  validation {
+    condition     = var.site_preview_secret != "ne"
+    error_message = "site_preview_secret must not equal the literal 'ne' (reserved for cookie clearing via ?nahled=ne)."
+  }
+}

--- a/static-pages/403.html
+++ b/static-pages/403.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Přístup odepřen — DIA</title>
+<style>
+  :root {
+    --bg: #f4f5f7;
+    --surface: #ffffff;
+    --text: #1a1a1a;
+    --muted: #5f6368;
+    --accent: #0b4f9c;
+    --border: #e1e3e6;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+  }
+  main {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    max-width: 32rem;
+    width: 100%;
+    padding: 2.5rem 2rem;
+    text-align: center;
+  }
+  .badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: rgba(11, 79, 156, 0.08);
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    margin-bottom: 1.25rem;
+  }
+  h1 {
+    font-size: 1.5rem;
+    margin: 0 0 0.75rem;
+    font-weight: 600;
+  }
+  p {
+    color: var(--muted);
+    margin: 0 0 0.75rem;
+    font-size: 0.95rem;
+  }
+  .footer {
+    margin-top: 2rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f1115;
+      --surface: #181b21;
+      --text: #f1f3f5;
+      --muted: #9aa0a6;
+      --accent: #6ea8ff;
+      --border: #2a2e36;
+    }
+  }
+</style>
+</head>
+<body>
+<main role="main">
+  <span class="badge">Přístup odepřen</span>
+  <h1>Přístup byl odepřen</h1>
+  <p>Tento požadavek nebyl povolen bezpečnostními pravidly aplikace.</p>
+  <p>Pokud máte za to, že jde o omyl, kontaktujte prosím správce systému.</p>
+  <div class="footer">DIA · Digitální a informační agentura</div>
+</main>
+</body>
+</html>

--- a/static-pages/502.html
+++ b/static-pages/502.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Služba je dočasně nedostupná — DIA</title>
+<style>
+  :root {
+    --bg: #f4f5f7;
+    --surface: #ffffff;
+    --text: #1a1a1a;
+    --muted: #5f6368;
+    --accent: #0b4f9c;
+    --border: #e1e3e6;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+  }
+  main {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    max-width: 32rem;
+    width: 100%;
+    padding: 2.5rem 2rem;
+    text-align: center;
+  }
+  .badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: rgba(11, 79, 156, 0.08);
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    margin-bottom: 1.25rem;
+  }
+  h1 {
+    font-size: 1.5rem;
+    margin: 0 0 0.75rem;
+    font-weight: 600;
+  }
+  p {
+    color: var(--muted);
+    margin: 0 0 0.75rem;
+    font-size: 0.95rem;
+  }
+  .footer {
+    margin-top: 2rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f1115;
+      --surface: #181b21;
+      --text: #f1f3f5;
+      --muted: #9aa0a6;
+      --accent: #6ea8ff;
+      --border: #2a2e36;
+    }
+  }
+</style>
+</head>
+<body>
+<main role="main">
+  <span class="badge">Služba nedostupná</span>
+  <h1>Služba je dočasně nedostupná</h1>
+  <p>Pracujeme na obnovení provozu. Zkuste to prosím za několik minut.</p>
+  <p>Pokud problém přetrvává, kontaktujte správce systému.</p>
+  <div class="footer">DIA · Digitální a informační agentura</div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Wires the runtime knobs that control the Coming Soon / Maintenance
gate on both frontends. Pairs with the matching `frontend/` and
`tool-frontend/` PRs.

## Module surface

Both `modules/validator_apps` and `modules/tool_apps`:

- New variable `site_status` (default `"live"`). Validation enforces
  one of `live | coming_soon | maintenance`.
- New variable `site_preview_secret` (sensitive, default `""`).
  Validation rejects the literal `"ne"` (reserved by the middleware
  for clearing the bypass cookie).
- Frontend Container App always exports `SITE_STATUS`.
- Frontend Container App gains a `dynamic "secret"` block that
  registers `site-preview-secret` only when the variable is non-empty,
  plus a `dynamic "env"` block that exposes `SITE_PREVIEW_SECRET`
  sourced from the secret only when configured.

When `site_preview_secret` is left empty, neither the secret nor the
env var is declared — the frontend then sees
`process.env.SITE_PREVIEW_SECRET` as `undefined` and the bypass
mechanism is fully disabled.

## Environment plumbing

`environments/{dev,test,prod}/variables.tf`:

- `tool_site_status` and `validator_site_status` — defaults: `live`
  for dev, `coming_soon` for test and prod.
- `tool_site_preview_secret` and `validator_site_preview_secret`
  (sensitive, default `""`).

`environments/{dev,test,prod}/main.tf`:

- Pass the four new variables through to the validator and tool
  modules.

## Behavior matrix

| `site_status` | `site_preview_secret` | Result |
|---|---|---|
| `live` | any | App served normally |
| `coming_soon` / `maintenance` | `""` | App fully gated, no bypass possible |
| `coming_soon` / `maintenance` | non-empty | App gated; `?nahled=<value>` grants a 30-day cookie |
| any | `"ne"` | Rejected by Terraform validation |
